### PR TITLE
Remove the contract instances from account info modal

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -160,7 +160,6 @@ export type AccountInfo = {
   accountCredentials: AccountCredential[];
   accountEncryptedAmount: EncryptedAmount;
   accountEncryptionKey: string;
-  accountInstances: ContractAddress[];
   accountNonce: number;
   accountReleaseSchedule: AccountReleaseSchedule;
 };

--- a/src/pages/account-info-modal.tsx
+++ b/src/pages/account-info-modal.tsx
@@ -148,15 +148,12 @@ export function AccountInfoModal() {
     [accountInfoQuery.data?.accountReleaseSchedule.schedule]
   );
 
-  const contractInstances = accountInfoQuery.data?.accountInstances ?? [];
-
   const accountInfo = {
     Address: whenDefined(
       (a) => <ClickToCopy copied={a} display={a.slice(0, 12)} />,
       address
     ),
     Balance: whenDefined(formatAmount, accountInfoQuery.data?.accountAmount),
-    "Contract instances": contractInstances.length,
     Scheduled: whenDefined(
       formatAmount,
       accountInfoQuery.data?.accountReleaseSchedule.total


### PR DESCRIPTION
## Purpose

Fix incorrect number of contract instances in account info modal.
This information is no longer exposed in this GRPC call.

## Changes

- Removed the row with contract instances