### PR TITLE
Use hash-router to fix 404 on reload

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,11 +1,6 @@
 import React, { useState } from "react";
 import { Icon, Menu, Sidebar } from "semantic-ui-react";
-import {
-  BrowserRouter as Router,
-  Switch,
-  NavLink,
-  Route,
-} from "react-router-dom";
+import { HashRouter as Router, Switch, NavLink, Route } from "react-router-dom";
 import { OverviewPage } from "./pages/overview";
 import { ConsensusPage } from "./pages/consensus";
 import { BlockExplorerPage } from "./pages/block-explorer";


### PR DESCRIPTION
## Purpose

The current nginx is not setup to serve a single page application, so it fails when reloading on a route besides `/`.

## Changes

- Use hash-router instead, which means the path will be prefixed with `#/` on every url.