### PR TITLE
Make nginx only proxy the nescessary GRPC calls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# This file only contains services ment for developing and testing the node-dashboard.
+# This file only contains services meant for developing and testing the node-dashboard.
 version: '3'
 services:
 
@@ -22,7 +22,7 @@ services:
       - ./grpc-api-client:/grpc-api-client
     command: bash /build_grpc-web-client.sh
 
-  # A service to quickly spin up an nginx service with the nginx config, ment for testing changes.
+  # A service to quickly spin up an nginx service with the nginx config, meant for testing changes.
   # Serves files from the dist directory created when building the node-dashboard.
   # IMPORTANT: Attaches directly to host network and ports.
   nginx-test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,19 @@
-
+# This file only contains services ment for developing and testing the node-dashboard.
 version: '3'
 services:
+
+  # Envoy proxy for developing locally.
+  # IMPORTANT: Attaches directly to host network and ports, this is nescessary for the
+  # container to reach a node running on the host.
   grpc-proxy:
     image: envoyproxy/envoy:v1.17.0
     network_mode: "host"
     volumes:
       - ./envoy.yaml:/etc/envoy/envoy.yaml:ro
     command: /usr/local/bin/envoy --config-path /etc/envoy/envoy.yaml
+
+  # Container with grpc-web build tools, and a script for building.
+  # This is only ment as a convenient way to build the GRPC-web typescript files.
   build-grpc:
     image: juanjodiaz/grpc-web-generator
     volumes:
@@ -14,6 +21,10 @@ services:
       - ./build_grpc-web-client.sh:/build_grpc-web-client.sh:ro
       - ./grpc-api-client:/grpc-api-client
     command: bash /build_grpc-web-client.sh
+
+  # A service to quickly spin up an nginx service with the nginx config, ment for testing changes.
+  # Serves files from the dist directory created when building the node-dashboard.
+  # IMPORTANT: Attaches directly to host network and ports.
   nginx-test:
     image: nginx
     network_mode: "host"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: envoyproxy/envoy:v1.17.0
     network_mode: "host"
     volumes:
-      - ./envoy.yaml:/etc/envoy/envoy.yaml
+      - ./envoy.yaml:/etc/envoy/envoy.yaml:ro
     command: /usr/local/bin/envoy --config-path /etc/envoy/envoy.yaml
   build-grpc:
     image: juanjodiaz/grpc-web-generator
@@ -14,3 +14,9 @@ services:
       - ./build_grpc-web-client.sh:/build_grpc-web-client.sh:ro
       - ./grpc-api-client:/grpc-api-client
     command: bash /build_grpc-web-client.sh
+  nginx-test:
+    image: nginx
+    network_mode: "host"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/node-dashboard.conf
+      - ./dist:/node-dashboard/static:ro

--- a/nginx.conf
+++ b/nginx.conf
@@ -16,8 +16,8 @@ server {
     try_files $uri $uri/ =404;
   }
 
-  # Forward requests to /concordium.P2P/ to the GRPC proxy.
-  location /concordium.P2P/ {
+  # Forward only the nescessary requests to the GRPC-web proxy.
+  location ~ ^/concordium\.P2P/(PeerVersion|PeerUptime|PeerTotalSent|PeerTotalReceived|PeerList|PeerStats|GetBannedPeers|NodeInfo|GetConsensusStatus|GetBirkParameters|GetAccountInfo|GetIdentityProviders)$ {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
@@ -26,4 +26,3 @@ server {
     proxy_redirect off;
   }
 }
-

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,6 +3,8 @@ upstream grpc_web_proxy {
   server	127.0.0.1:9999;
 }
 
+limit_req_zone $binary_remote_addr zone=grpclimit:10m rate=10r/s;
+
 server {
   listen 8099 default_server;
   listen [::]:8099 default_server;
@@ -18,6 +20,8 @@ server {
 
   # Forward only the nescessary requests to the GRPC-web proxy.
   location ~ ^/concordium\.P2P/(PeerVersion|PeerUptime|PeerTotalSent|PeerTotalReceived|PeerList|PeerStats|GetBannedPeers|NodeInfo|GetConsensusStatus|GetBirkParameters|GetAccountInfo|GetIdentityProviders)$ {
+    limit_req zone=grpclimit;
+
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;


### PR DESCRIPTION
## Purpose

Right now every GRPC call is available to the node-dashboard, even calls that are not needed.

## Changes

- Have NGINX only proxy the needed subset of GRPC calls, everything else will result in 404.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
