### PR TITLE
Support concordium nodes with RPC tokens different from the default

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,19 +1,14 @@
 import { UnwrapPromiseRec, whenDefined } from "./utils";
 import { P2PPromiseClient } from "../grpc-api-client/concordium_p2p_rpc_grpc_web_pb";
 import * as T from "../grpc-api-client/concordium_p2p_rpc_pb";
+import { Metadata } from "grpc-web";
+export { Error as ConnectionError, StatusCode as ErrorCode } from "grpc-web";
 
 // Constants
 
 // If GRPC_WEB_HOST is not set at build time, assume that we can access GRPC on the same host.
 // This requires the server to be configured correctly for proxying.
-const grpcWebHost =
-  process.env.GRPC_WEB_HOST ??
-  window.location.protocol + "//" + window.location.host;
 
-console.info("Connecting to node GRPC at ", grpcWebHost);
-
-const client = new P2PPromiseClient(grpcWebHost);
-const meta = { authentication: "rpcadmin" };
 const empty = new T.Empty();
 
 // Types
@@ -183,10 +178,11 @@ type AnonymityRevoker = {
   arDescription: IpOrArDescription;
 };
 
-export type PeersInfo = UnwrapPromiseRec<ReturnType<typeof fetchPeersInfo>>;
-export type PeerInfo = UnwrapPromiseRec<ReturnType<typeof fetchPeerInfo>>;
+export type Client = UnwrapPromiseRec<ReturnType<typeof connect>>;
 
-export type NodeInfo = UnwrapPromiseRec<ReturnType<typeof fetchNodeInfo>>;
+export type PeersInfo = UnwrapPromiseRec<ReturnType<Client["fetchPeersInfo"]>>;
+export type PeerInfo = UnwrapPromiseRec<ReturnType<Client["fetchPeerInfo"]>>;
+export type NodeInfo = UnwrapPromiseRec<ReturnType<Client["fetchNodeInfo"]>>;
 
 // Helper functions
 
@@ -246,197 +242,205 @@ function isInBakingCommitteeToString(
   }
 }
 
-// API functions
-
-export async function fetchNodeInfo() {
-  const res = await client.nodeInfo(empty, meta);
-
-  return {
-    id: getGoogleStringValue(res.getNodeId()),
-    localTime: new Date(res.getCurrentLocaltime() * 1000),
-    inBakingCommittee: isInBakingCommitteeToString(
-      res.getConsensusBakerCommittee()
-    ),
-    bakerId: getGoogleIntValue(res.getConsensusBakerId()),
-    bakerRunning: res.getConsensusBakerRunning(),
-    inFinalizationCommittee: res.getConsensusFinalizerCommittee(),
-  } as const;
-}
-
-export async function fetchPeersInfo() {
-  const peersRequest = new T.PeersRequest();
-  peersRequest.setIncludeBootstrappers(false);
-
-  const [listRes, statsRes, bannedRes] = await Promise.all([
-    client.peerList(peersRequest, meta),
-    client.peerStats(peersRequest, meta),
-    client.getBannedPeers(empty, meta),
-  ]);
-
-  const peerStatsMap = new Map(
-    statsRes.getPeerstatsList().map((s) => [
-      s.getNodeId(),
-      {
-        packetsSent: s.getPacketsSent(),
-        packetsReceived: s.getPacketsReceived(),
-        latency: s.getLatency(),
-      },
-    ])
-  );
-
-  const peers = listRes.getPeersList().map((peer) => {
-    const id = getGoogleStringValue(peer.getNodeId());
-    const stats = id !== undefined ? peerStatsMap.get(id) : undefined;
-    const ip = getGoogleStringValue(peer.getIp());
-    const port = getGoogleIntValue(peer.getPort());
-    return {
-      id,
-      ip,
-      port,
-      status: catchupStatusToString(peer.getCatchupStatus()),
-      stats,
-    } as const;
-  });
-
-  const banned = bannedRes.getPeersList().map((peer) => {
-    const id = getGoogleStringValue(peer.getNodeId());
-    const ip = getGoogleStringValue(peer.getIp());
-    const port = getGoogleIntValue(peer.getPort());
-    return {
-      id,
-      ip,
-      port,
-    };
-  });
+/** Create a client for a given grpc-web host and with a given metadata */
+export function connect(grpcWebHost: string, meta?: Metadata) {
+  const client = new P2PPromiseClient(grpcWebHost);
 
   return {
-    avgBpsIn: statsRes.getAvgBpsIn(),
-    avgBpsOut: statsRes.getAvgBpsOut(),
-    peers,
-    banned,
+    async nodeVersion() {
+      const res = await client.peerVersion(empty, meta);
+      return res.getValue();
+    },
+
+    async fetchNodeInfo() {
+      const res = await client.nodeInfo(empty, meta);
+
+      return {
+        id: getGoogleStringValue(res.getNodeId()),
+        localTime: new Date(res.getCurrentLocaltime() * 1000),
+        inBakingCommittee: isInBakingCommitteeToString(
+          res.getConsensusBakerCommittee()
+        ),
+        bakerId: getGoogleIntValue(res.getConsensusBakerId()),
+        bakerRunning: res.getConsensusBakerRunning(),
+        inFinalizationCommittee: res.getConsensusFinalizerCommittee(),
+      } as const;
+    },
+
+    async fetchPeersInfo() {
+      const peersRequest = new T.PeersRequest();
+      peersRequest.setIncludeBootstrappers(false);
+
+      const [listRes, statsRes, bannedRes] = await Promise.all([
+        client.peerList(peersRequest, meta),
+        client.peerStats(peersRequest, meta),
+        client.getBannedPeers(empty, meta),
+      ]);
+
+      const peerStatsMap = new Map(
+        statsRes.getPeerstatsList().map((s) => [
+          s.getNodeId(),
+          {
+            packetsSent: s.getPacketsSent(),
+            packetsReceived: s.getPacketsReceived(),
+            latency: s.getLatency(),
+          },
+        ])
+      );
+
+      const peers = listRes.getPeersList().map((peer) => {
+        const id = getGoogleStringValue(peer.getNodeId());
+        const stats = id !== undefined ? peerStatsMap.get(id) : undefined;
+        const ip = getGoogleStringValue(peer.getIp());
+        const port = getGoogleIntValue(peer.getPort());
+        return {
+          id,
+          ip,
+          port,
+          status: catchupStatusToString(peer.getCatchupStatus()),
+          stats,
+        } as const;
+      });
+
+      const banned = bannedRes.getPeersList().map((peer) => {
+        const id = getGoogleStringValue(peer.getNodeId());
+        const ip = getGoogleStringValue(peer.getIp());
+        const port = getGoogleIntValue(peer.getPort());
+        return {
+          id,
+          ip,
+          port,
+        };
+      });
+
+      return {
+        avgBpsIn: statsRes.getAvgBpsIn(),
+        avgBpsOut: statsRes.getAvgBpsOut(),
+        peers,
+        banned,
+      };
+    },
+
+    async fetchPeerInfo() {
+      const [
+        resVersion,
+        resPeerUpTime,
+        packetsSent,
+        packetsReceived,
+      ] = await Promise.all([
+        client.peerVersion(empty, meta),
+        client.peerUptime(empty, meta),
+        client.peerTotalSent(empty, meta),
+        client.peerTotalReceived(empty, meta),
+      ]);
+      return {
+        version: resVersion.getValue(),
+        uptime: resPeerUpTime.getValue(),
+        packetsSent: packetsSent.getValue(),
+        packetsReceived: packetsReceived.getValue(),
+      };
+    },
+
+    async fetchConsensusInfo(): Promise<ConsensusInfo> {
+      const res = await client.getConsensusStatus(empty, meta);
+
+      const json = JSON.parse(res.getValue());
+
+      // Parsing date fields into Date objects
+      const dateFields = [
+        "blockLastArrivedTime",
+        "blockLastReceivedTime",
+        "genesisTime",
+        "lastFinalizedTime",
+      ];
+      for (const field of dateFields) {
+        const dateString = json[field];
+        if (dateString !== null) {
+          json[field] = new Date(Date.parse(dateString));
+        }
+      }
+      return json;
+    },
+
+    async fetchBirkParameters(blockHash: string): Promise<BirkParametersInfo> {
+      const request = new T.BlockHash();
+      request.setBlockHash(blockHash);
+      const res = await client.getBirkParameters(request, meta);
+      return JSON.parse(res.getValue());
+    },
+
+    async fetchAccountInfo(
+      blockHash: string,
+      accountAddress: string
+    ): Promise<AccountInfo> {
+      const request = new T.GetAddressInfoRequest();
+      request.setBlockHash(blockHash);
+      request.setAddress(accountAddress);
+
+      const res = await client.getAccountInfo(request, meta);
+      const json = JSON.parse(res.getValue());
+
+      // Parse amount strings
+      json.accountAmount = parseAmountString(json.accountAmount);
+      whenDefined(
+        (a) => (json.accountBaker.stakedAmount = parseAmountString(a)),
+        json.accountBaker?.stakedAmount
+      );
+
+      // Parse credential dates
+      json.accountCredentials = Object.values(json.accountCredentials);
+      for (const cred of json.accountCredentials) {
+        const { policy } = cred.value.contents;
+        policy.createdAt = parsePolicyDate(policy.createdAt);
+        policy.validTo = parsePolicyDate(policy.validTo);
+      }
+
+      // Parse release schedule
+      json.accountReleaseSchedule.total = parseAmountString(
+        json.accountReleaseSchedule.total
+      );
+      for (const schedule of json.accountReleaseSchedule.schedule) {
+        schedule.amount = parseAmountString(schedule.amount);
+        schedule.timestamp = new Date(schedule.timestamp);
+      }
+
+      return json;
+    },
+
+    async fetchIdentityProviders(
+      blockHash: string
+    ): Promise<Map<number, IdentityProvider>> {
+      const request = new T.BlockHash();
+      request.setBlockHash(blockHash);
+
+      const res = await client.getIdentityProviders(request, meta);
+      const json: IdentityProvider[] = JSON.parse(res.getValue());
+      const map = new Map(json.map((ip) => [ip.ipIdentity, ip]));
+      return map;
+    },
+
+    async fetchAnonymityRevokers(blockHash: string) {
+      const request = new T.BlockHash();
+      request.setBlockHash(blockHash);
+
+      const res = await client.getAnonymityRevokers(request, meta);
+      const json: AnonymityRevoker[] = JSON.parse(res.getValue());
+      const map = new Map(json.map((ar) => [ar.arIdentity, ar]));
+      return map;
+    },
+
+    async banNode(nodeId: string) {
+      const node = new T.PeerElement();
+      node.setNodeId(createGoogleValue(nodeId));
+      const res = await client.banNode(node, meta);
+      return res.getValue();
+    },
+
+    async unbanNode(nodeId: string) {
+      const node = new T.PeerElement();
+      node.setNodeId(createGoogleValue(nodeId));
+      const res = await client.unbanNode(node, meta);
+      return res.getValue();
+    },
   };
-}
-
-export async function fetchPeerInfo() {
-  const [
-    resVersion,
-    resPeerUpTime,
-    packetsSent,
-    packetsReceived,
-  ] = await Promise.all([
-    client.peerVersion(empty, meta),
-    client.peerUptime(empty, meta),
-    client.peerTotalSent(empty, meta),
-    client.peerTotalReceived(empty, meta),
-  ]);
-  return {
-    version: resVersion.getValue(),
-    uptime: resPeerUpTime.getValue(),
-    packetsSent: packetsSent.getValue(),
-    packetsReceived: packetsReceived.getValue(),
-  };
-}
-
-export async function fetchConsensusInfo(): Promise<ConsensusInfo> {
-  const res = await client.getConsensusStatus(empty, meta);
-
-  const json = JSON.parse(res.getValue());
-
-  // Parsing date fields into Date objects
-  const dateFields = [
-    "blockLastArrivedTime",
-    "blockLastReceivedTime",
-    "genesisTime",
-    "lastFinalizedTime",
-  ];
-  for (const field of dateFields) {
-    const dateString = json[field];
-    if (dateString !== null) {
-      json[field] = new Date(Date.parse(dateString));
-    }
-  }
-  return json;
-}
-
-export async function fetchBirkParameters(
-  blockHash: string
-): Promise<BirkParametersInfo> {
-  const request = new T.BlockHash();
-  request.setBlockHash(blockHash);
-  const res = await client.getBirkParameters(request, meta);
-  return JSON.parse(res.getValue());
-}
-
-export async function fetchAccountInfo(
-  blockHash: string,
-  accountAddress: string
-): Promise<AccountInfo> {
-  const request = new T.GetAddressInfoRequest();
-  request.setBlockHash(blockHash);
-  request.setAddress(accountAddress);
-
-  const res = await client.getAccountInfo(request, meta);
-  const json = JSON.parse(res.getValue());
-
-  // Parse amount strings
-  json.accountAmount = parseAmountString(json.accountAmount);
-  whenDefined(
-    (a) => (json.accountBaker.stakedAmount = parseAmountString(a)),
-    json.accountBaker?.stakedAmount
-  );
-
-  // Parse credential dates
-  json.accountCredentials = Object.values(json.accountCredentials);
-  for (const cred of json.accountCredentials) {
-    const { policy } = cred.value.contents;
-    policy.createdAt = parsePolicyDate(policy.createdAt);
-    policy.validTo = parsePolicyDate(policy.validTo);
-  }
-
-  // Parse release schedule
-  json.accountReleaseSchedule.total = parseAmountString(
-    json.accountReleaseSchedule.total
-  );
-  for (const schedule of json.accountReleaseSchedule.schedule) {
-    schedule.amount = parseAmountString(schedule.amount);
-    schedule.timestamp = new Date(schedule.timestamp);
-  }
-
-  return json;
-}
-
-export async function fetchIdentityProviders(
-  blockHash: string
-): Promise<Map<number, IdentityProvider>> {
-  const request = new T.BlockHash();
-  request.setBlockHash(blockHash);
-
-  const res = await client.getIdentityProviders(request, meta);
-  const json: IdentityProvider[] = JSON.parse(res.getValue());
-  const map = new Map(json.map((ip) => [ip.ipIdentity, ip]));
-  return map;
-}
-
-export async function fetchAnonymityRevokers(blockHash: string) {
-  const request = new T.BlockHash();
-  request.setBlockHash(blockHash);
-
-  const res = await client.getAnonymityRevokers(request, meta);
-  const json: AnonymityRevoker[] = JSON.parse(res.getValue());
-  const map = new Map(json.map((ar) => [ar.arIdentity, ar]));
-  return map;
-}
-
-export async function banNode(nodeId: string) {
-  const node = new T.PeerElement();
-  node.setNodeId(createGoogleValue(nodeId));
-  const res = await client.banNode(node, meta);
-  return res.getValue();
-}
-
-export async function unbanNode(nodeId: string) {
-  const node = new T.PeerElement();
-  node.setNodeId(createGoogleValue(nodeId));
-  const res = await client.unbanNode(node, meta);
-  return res.getValue();
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -10,13 +10,16 @@ import logoWithText from "./assets/concordium-text.svg";
 import { useDeviceScreen } from "./utils";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { AccountInfoModal } from "./pages/account-info-modal";
+import { ProvideApi } from "./provide-api";
 
 const queryClient = new QueryClient();
 
 export function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <Navigation />
+      <ProvideApi>
+        <Navigation />
+      </ProvideApi>
     </QueryClientProvider>
   );
 }

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Concordium Node</title>
+    <title>Concordium Node Dashboard</title>
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link

--- a/src/pages/account-info-modal.tsx
+++ b/src/pages/account-info-modal.tsx
@@ -25,6 +25,7 @@ import {
 } from "semantic-ui-react";
 import { capitalize, isEmpty } from "lodash";
 import { Column } from "react-table";
+import { useApiClient } from "../provide-api";
 
 const accountInfoSearch = "account-info";
 const blockhashSearch = "blockhash";
@@ -68,6 +69,7 @@ export function useAccountInfoSearchQuery() {
  * the form of url search parameters.
  */
 export function AccountInfoModal() {
+  const client = useApiClient();
   const {
     showing,
     address,
@@ -77,7 +79,7 @@ export function AccountInfoModal() {
 
   const consensusInfoQuery = useQuery(
     ["ConsensusInfo"],
-    API.fetchConsensusInfo,
+    client.fetchConsensusInfo,
     {
       refetchInterval: queryBlochHash === undefined ? 4000 : false,
       enabled: showing,
@@ -88,13 +90,13 @@ export function AccountInfoModal() {
 
   const accountInfoQuery = useQuery(
     ["AccountInfo", blockHash, address],
-    () => whenDefined(API.fetchAccountInfo, blockHash, address),
+    () => whenDefined(client.fetchAccountInfo, blockHash, address),
     { enabled: showing, keepPreviousData: showing }
   );
 
   const identityProvidersQuery = useQuery(
     ["IdentityProviders"],
-    () => whenDefined(API.fetchIdentityProviders, blockHash),
+    () => whenDefined(client.fetchIdentityProviders, blockHash),
     { enabled: showing, keepPreviousData: true, staleTime: Infinity }
   );
 

--- a/src/pages/consensus.tsx
+++ b/src/pages/consensus.tsx
@@ -26,6 +26,7 @@ import {
 import * as API from "../api";
 import { useAccountInfoSearchQuery } from "./account-info-modal";
 import { useQuery } from "react-query";
+import { useApiClient } from "../provide-api";
 
 const msInADay = 1000 * 60 * 60 * 24;
 const msInAWeek = msInADay * 7;
@@ -34,10 +35,11 @@ const msInAYear = msInAMonth * 12;
 
 export function ConsensusPage() {
   const accountInfo = useAccountInfoSearchQuery();
+  const client = useApiClient();
 
   const consensusQuery = useQuery<API.ConsensusInfo, Error>(
     ["ConsensusInfo"],
-    API.fetchConsensusInfo,
+    client.fetchConsensusInfo,
     {
       refetchInterval: 4000,
       keepPreviousData: true,
@@ -46,7 +48,7 @@ export function ConsensusPage() {
   );
   const nodeQuery = useQuery<API.NodeInfo, Error>(
     ["NodeInfo"],
-    API.fetchNodeInfo,
+    client.fetchNodeInfo,
     {
       refetchInterval: 4000,
       keepPreviousData: true,
@@ -64,7 +66,7 @@ export function ConsensusPage() {
     ["BirkInfo", epochIndex],
     () =>
       whenDefined(
-        (block) => API.fetchBirkParameters(block),
+        (block) => client.fetchBirkParameters(block),
         consensusQuery.data?.bestBlock
       ),
     { enabled: consensusQuery.data?.bestBlock !== undefined }

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -34,6 +34,7 @@ import {
 } from "../shared";
 import { Column } from "react-table";
 import { useAccountInfoSearchQuery } from "./account-info-modal";
+import { useApiClient } from "../provide-api";
 
 /** The number of milliseconds a node's localTime must be off, for a warning to appear. */
 const nodeLocalTimeOffset = 1000;
@@ -47,11 +48,12 @@ const maximumMillisOfLastBlockReceived = 300000;
 const maximumMillisOfLastBlockFinalized = 600000;
 
 export function OverviewPage() {
+  const client = useApiClient();
   const accountInfo = useAccountInfoSearchQuery();
 
   const nodeQuery = useQuery<API.NodeInfo, Error>(
     ["NodeInfo"],
-    API.fetchNodeInfo,
+    client.fetchNodeInfo,
     {
       refetchInterval: 10000,
       enabled: !accountInfo.showing,
@@ -59,7 +61,7 @@ export function OverviewPage() {
   );
   const consensusQuery = useQuery<API.ConsensusInfo, Error>(
     ["ConsensusInfo"],
-    API.fetchConsensusInfo,
+    client.fetchConsensusInfo,
     {
       refetchInterval: 4000,
       enabled: !accountInfo.showing,
@@ -67,7 +69,7 @@ export function OverviewPage() {
   );
   const peerQuery = useQuery<API.PeerInfo, Error>(
     ["PeerInfo"],
-    API.fetchPeerInfo,
+    client.fetchPeerInfo,
     {
       refetchInterval: 10000,
       enabled: !accountInfo.showing,
@@ -75,7 +77,7 @@ export function OverviewPage() {
   );
   const peersQuery = useQuery<API.PeersInfo, Error>(
     ["PeersInfo"],
-    API.fetchPeersInfo,
+    client.fetchPeersInfo,
     {
       refetchInterval: 10000,
       enabled: !accountInfo.showing,
@@ -93,7 +95,7 @@ export function OverviewPage() {
     ["BirkInfo", epochIndex],
     () =>
       whenDefined(
-        (block) => API.fetchBirkParameters(block),
+        (block) => client.fetchBirkParameters(block),
         consensusQuery.data?.bestBlock
       ),
     {
@@ -116,7 +118,7 @@ export function OverviewPage() {
     ],
     () =>
       whenDefined(
-        (blockHash, address) => API.fetchAccountInfo(blockHash, address),
+        (blockHash, address) => client.fetchAccountInfo(blockHash, address),
         consensusQuery.data?.bestBlock,
         nodeBirkBaker?.bakerAccount
       ),
@@ -488,7 +490,7 @@ export function OverviewPage() {
                   icon="handshake outline"
                   basic
                   onClick={() =>
-                    whenDefined((id) => API.unbanNode(id), peer.id)
+                    whenDefined((id) => client.unbanNode(id), peer.id)
                   }
                 />
               }

--- a/src/provide-api.tsx
+++ b/src/provide-api.tsx
@@ -1,0 +1,150 @@
+import React, {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import * as API from "./api";
+import { useQuery } from "react-query";
+import { Button, Container, Form, Grid, Header } from "semantic-ui-react";
+
+const ApiClientContext = createContext<API.Client | undefined>(undefined);
+
+export function useApiClient() {
+  const client = useContext(ApiClientContext);
+  if (client === undefined) {
+    throw new Error("Failed to provide an ApiClient through a context");
+  }
+  return client;
+}
+
+// If GRPC_WEB_HOST is not set at build time, assume that we can access GRPC on the same host.
+// This requires the server to be configured correctly for proxying.
+const grpcWebHost =
+  process.env.GRPC_WEB_HOST ??
+  window.location.protocol + "//" + window.location.host;
+
+const rpcTokenStorageKey = "GRPC_AUTHENTICATION_TOKEN";
+
+function saveRpcToken(value: string) {
+  const entry = JSON.stringify({
+    version: 0,
+    value,
+  });
+  localStorage.setItem(rpcTokenStorageKey, entry);
+}
+
+function getRpcToken(): string | undefined {
+  const entry = localStorage.getItem(rpcTokenStorageKey);
+  if (entry === null) {
+    return undefined;
+  }
+  return JSON.parse(entry).value;
+}
+
+const defaultRpcToken = "rpcadmin";
+
+type ConnectedProps = {
+  children: ReactNode;
+};
+
+export function ProvideApi(props: ConnectedProps) {
+  const [authentication, setAuthentication] = useState(getRpcToken());
+
+  const client = useMemo(
+    () =>
+      API.connect(grpcWebHost, {
+        authentication: authentication ?? defaultRpcToken,
+      }),
+    [authentication]
+  );
+
+  const connectionCheckQuery = useQuery<string, API.ConnectionError>(
+    ["nodeVersion", authentication],
+    client.nodeVersion,
+    { retry: false, refetchOnMount: false, retryOnMount: false }
+  );
+
+  useEffect(() => {
+    if (connectionCheckQuery.isSuccess && authentication !== undefined) {
+      saveRpcToken(authentication);
+    }
+  }, [authentication, connectionCheckQuery.isSuccess]);
+
+  if (connectionCheckQuery.isLoading) {
+    return <Centered>Connecting to the Concordium Node</Centered>;
+  }
+
+  if (
+    connectionCheckQuery.error !== null &&
+    connectionCheckQuery.error.code === API.ErrorCode.UNAUTHENTICATED
+  ) {
+    return <ConnectionSettings onNewSettings={setAuthentication} />;
+  }
+
+  return (
+    <ApiClientContext.Provider value={client}>
+      {props.children}
+    </ApiClientContext.Provider>
+  );
+}
+
+type ConnectionSettingsProps = {
+  onNewSettings: (authentication: string) => void;
+};
+
+function ConnectionSettings(props: ConnectionSettingsProps) {
+  const [authenticationField, setAuthenticationField] = useState("");
+
+  const onSubmit = () => props.onNewSettings(authenticationField);
+  return (
+    <Centered>
+      <div
+        style={{
+          border: "1px solid lightgrey",
+          borderRadius: 5,
+          padding: "1em",
+        }}
+      >
+        <Header>Failed to connect to node: Unauthenticated</Header>
+        <p>Check the GRPC token is correct and try again</p>
+        <Form>
+          <Form.Field>
+            <label>GRPC authentication token</label>
+            <input
+              placeholder={`${defaultRpcToken}`}
+              value={authenticationField}
+              onChange={(e) => setAuthenticationField(e.target.value)}
+            />
+          </Form.Field>
+          <Button type="submit" onClick={onSubmit} primary>
+            Connect
+          </Button>
+        </Form>
+      </div>
+    </Centered>
+  );
+}
+
+type CenteredProps = {
+  children: ReactNode;
+};
+
+function Centered(props: CenteredProps) {
+  return (
+    <Container style={{ height: "100%" }}>
+      <Grid
+        verticalAlign="middle"
+        columns={3}
+        centered
+        style={{ height: "100%" }}
+      >
+        <Grid.Row>
+          <Grid.Column>{props.children}</Grid.Column>
+        </Grid.Row>
+      </Grid>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Purpose

Support concordium nodes with RPC tokens different from the default

## Changes
- First check the connection the node GRPC using the default token and if it returns unauthorized, prompt the user for a differerent token.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

