### PR TITLE
Two instances per IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ npm run build
 
 ## Releasing
 
-
 As this is shipped as part of the concordium-node container, the image for the concordium-node contains the runtime dependencies (nginx and envoy),
 but uses the image `192549843005.dkr.ecr.eu-west-1.amazonaws.com/concordium/node-dashboard`
 for the configuration and static files for the node dashboard.
@@ -119,3 +118,5 @@ docker push 192549843005.dkr.ecr.eu-west-1.amazonaws.com/concordium/node-dashboa
 
 To use in staging and/or testnet, update the version found in the dockerfiles
 found in concordium node repository.
+
+*Note:* The NGINX only exposes the needed calls for the GRPC-web proxy and puts a rate-limit on the requests to support up to two views of the node dashboard per IP.

--- a/nginx.conf
+++ b/nginx.conf
@@ -20,6 +20,7 @@ server {
 
   # Forward only the nescessary requests to the GRPC-web proxy.
   location ~ ^/concordium\.P2P/(PeerVersion|PeerUptime|PeerTotalSent|PeerTotalReceived|PeerList|PeerStats|GetBannedPeers|NodeInfo|GetConsensusStatus|GetBirkParameters|GetAccountInfo|GetIdentityProviders)$ {
+    # Rate limit to only support two views of the node dashboard per IP
     limit_req zone=grpclimit burst=20 delay=15;
 
     proxy_set_header X-Real-IP $remote_addr;

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,7 +3,7 @@ upstream grpc_web_proxy {
   server	127.0.0.1:9999;
 }
 
-limit_req_zone $binary_remote_addr zone=grpclimit:10m rate=10r/s;
+limit_req_zone $binary_remote_addr zone=grpclimit:10m rate=3r/s;
 
 server {
   listen 8099 default_server;
@@ -20,7 +20,7 @@ server {
 
   # Forward only the nescessary requests to the GRPC-web proxy.
   location ~ ^/concordium\.P2P/(PeerVersion|PeerUptime|PeerTotalSent|PeerTotalReceived|PeerList|PeerStats|GetBannedPeers|NodeInfo|GetConsensusStatus|GetBirkParameters|GetAccountInfo|GetIdentityProviders)$ {
-    limit_req zone=grpclimit;
+    limit_req zone=grpclimit burst=20 delay=15;
 
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -11,7 +11,14 @@ import { useDeviceScreen } from "./utils";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { AccountInfoModal } from "./pages/account-info-modal";
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: false,
+    },
+  },
+});
 
 export function App() {
   return (


### PR DESCRIPTION
## Purpose

The rate limit should only allow requests from two instances per IP address.
Meaning if you have 3 browser windows open with the node dashboard you will start to see errors.

## Changes

- Set rate limit to 3 requests per second and allow bursts of 20.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

